### PR TITLE
Update dependency to allow the project to build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 chrono = { version = "0.3", features = ["serde", "rustc-serialize"] }
 hyper = "0.10.4"
-hyper-rustls = "0.3.1"
+hyper-rustls = "0.5.0"
 serde = "0.9"
 serde_json = "0.9"
 serde_derive = "0.9"


### PR DESCRIPTION
Fixing the following error:
no matching version `^0.8.0` found for package `webpki`
location searched: registry `https://github.com/rust-lang/crates.io-index`
versions found: 0.18.1, 0.18.0, 0.17.0, ...
required by package `webpki-roots v0.6.0`
    ... which is depended on by `hyper-rustls v0.3.1`
    ... which is depended on by `twitch_api v0.1.1`